### PR TITLE
Switching font-feature-setting from pnum to tnum

### DIFF
--- a/components/base/_typography.scss
+++ b/components/base/_typography.scss
@@ -1,5 +1,8 @@
 body {
-  font-feature-settings: "kern", "liga", "pnum";
+  font-variant-numeric: tabular-nums;
+  -moz-font-feature-settings: "tnum";
+  -webkit-font-feature-settings: "tnum";
+  font-feature-settings: "kern", "liga", "tnum";
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;


### PR DESCRIPTION
Because we work with numbers in our UIs a lot, it makes sense to use tabular numbers feature supported by Acumin Pro. It effectively "monospaces" all number glyphs, so that numbers with the same digit count are displayed with the exact same width for scannability.