### PR TITLE
feat(breakpoint): Added a new breakpoint for small desktop devices

### DIFF
--- a/utils/_grid.scss
+++ b/utils/_grid.scss
@@ -232,31 +232,9 @@ $last-child-float: $opposite-direction !default;
         }
     }
 
-    @media #{$small-up} {
-        @include grid-html-classes($size:small);
-    }
-
-    @media #{$medium-up} {
-        @include grid-html-classes($size:medium);
-        // Old push and pull classes
-        @for $i from 0 through $total-columns - 1 {
-            .push-#{$i} {
-                @include grid-column($push:$i, $collapse:null, $float:false);
-            }
-            .pull-#{$i} {
-                @include grid-column($pull:$i, $collapse:null, $float:false);
-            }
-        }
-    }
-    @media #{$large-up} {
-        @include grid-html-classes($size:large);
-        @for $i from 0 through $total-columns - 1 {
-            .push-#{$i} {
-                @include grid-column($push:$i, $collapse:null, $float:false);
-            }
-            .pull-#{$i} {
-                @include grid-column($pull:$i, $collapse:null, $float:false);
-            }
+    @each $breakpoint in map-keys($breakpoints) {
+        @media #{map-get($breakpoints, $breakpoint)} {
+            @include grid-html-classes($size: $breakpoint);
         }
     }
 }

--- a/utils/variables/_breakpoints.scss
+++ b/utils/variables/_breakpoints.scss
@@ -1,9 +1,11 @@
-$small-up: screen !default;
-$medium-up: screen and (min-width: 40em) !default; // Do we need Tablet?
-$large-up: screen and (min-width: 90.0625em) !default; // Bigger than mac's 2880px with 2 dpi = 1440px
+$small-up: "screen" !default; // 0 - 640px
+$medium-up: "screen and (min-width: 40.0625em)" !default; // 641px - 1024px
+$large-up: "screen and (min-width: 64.0625em)" !default; // 1025px - 1440px
+$xlarge-up: "screen and (min-width: 90.0625em)" !default; // Bigger than mac's 2880px with 2 dpi = 1441px
 
 $breakpoints: (
     small: $small-up,
     medium: $medium-up,
-    large: $large-up
+    large: $large-up,
+    xlarge: $xlarge-up,
 ) !default;


### PR DESCRIPTION
I added a new breakpoint to target desktop devices with small resolution like mac books.
Now we have the following break points:
small -> 0px and up = Mobile devices
medium -> 641px and up = Tablets
large -> 1025px and up = Small desktops
xlarge -> 1441px and up = Large desktops

Since the grid classes are now generated automatically the large class is acting a bit earlier than before.
Example grid usage now could be
```html
<div class="row">
  <div class="column small-24 medium-22 xlarge-16">
     <div class="card">
        some content
      </div>
  </div>
</div>
```