### PR TITLE
Implemented styles for radio groups

### DIFF
--- a/atoms/_buttons.scss
+++ b/atoms/_buttons.scss
@@ -19,12 +19,17 @@ $button-shadows: (
   disabled: none
 ) !default;
 
+/**
+ * Includes css for the general button styling
+ */
 @mixin button-base() {
   font-family: $base-font-family;
   -webkit-font-smoothing: antialiased;
-  line-height: 1;
+  font-weight: bold;
+  text-transform: uppercase;
   text-decoration: none;
   text-align: center;
+  line-height: 1rem;
   user-select: none;
   border: 1px solid transparent;
   border-radius: $button-border-radius;
@@ -38,6 +43,11 @@ $button-shadows: (
   @include transition(all .2s);
 }
 
+/**
+ * Includes colors and shadows for buttons
+ * @param color $background
+ * @param color $foreground
+ */
 @mixin button-style($background, $foreground) {
   background-color: $background;
   color: $foreground;
@@ -53,23 +63,74 @@ $button-shadows: (
   }
 }
 
-@mixin button-small() {
+/**
+ * Includes css to make a button small
+ */
+@mixin button-size-small() {
   font-size: map-get($button-sizes, small);
+  line-height: map-get($button-sizes, small);
 }
 
-@mixin button-medium() {
+/**
+ * Includes css to make a button medium
+ */
+@mixin button-size-medium() {
   font-size: map-get($button-sizes, medium);
+  line-height: map-get($button-sizes, medium);
 }
 
-@mixin button-large() {
+/**
+ * Includes css to make a button large
+ */
+@mixin button-size-large() {
   font-size: map-get($button-sizes, large);
+  line-height: map-get($button-sizes, large);
 }
 
+/**
+ * Includes css for a button in disabled state
+ * @param color $color
+ * @param color $background
+ */
 @mixin button-disabled($color, $background) {
   cursor: not-allowed;
   color: $color;
   background-color: $background;
   box-shadow: map-get($button-shadows, disabled);
+}
+
+/**
+ * Includes css for a button of type toggle
+ */
+@mixin button-type-toggle() {
+  @include button-style($secondary-color, $asphalt);
+  &:active,
+  &.is-active {
+    box-shadow: $paper-shadow-1;
+    color: $primary-color;
+  }
+  &:disabled,
+  &.is-disabled {
+    color: $ghost;
+    cursor: not-allowed;
+  }
+}
+
+/**
+ * Includes css for a button of type flat
+ */
+@mixin button-type-flat() {
+  @include button-style(transparent, $primary-color);
+  box-shadow: none;
+  &:hover,
+  &.is-hovered {
+    box-shadow: $paper-shadow-2;
+    background-color: $catkin;
+  }
+  &:active,
+  &.is-active {
+    box-shadow: none;
+  }
 }
 
 @if $export-button-css {
@@ -80,12 +141,12 @@ $button-shadows: (
   input[type="submit"] {
     @include button-base;
     @include button-style($button-background, $button-color);
-    @include button-medium;
+    @include button-size-medium;
     &.mod-large {
-      @include button-large;
+      @include button-size-large;
     }
     &.mod-small {
-      @include button-small;
+      @include button-size-small;
     }
     &:disabled, &.is-disabled {
       @include button-disabled($button-color-disabled, $button-background-disabled);
@@ -94,29 +155,10 @@ $button-shadows: (
       @include button-style($secondary-color, $asphalt);
     }
     &.mod-toggle {
-      @include button-style($secondary-color, $asphalt);
-      &:active,
-      &.is-active {
-        box-shadow: map-get($button-shadows, hover);
-      }
-      &:disabled,
-      &.is-disabled {
-        color: $asphalt;
-        cursor: not-allowed;
-      }
+      @include button-type-toggle;
     }
     &.mod-flat {
-      @include button-style(transparent, $primary-color);
-      box-shadow: none;
-      &:hover,
-      &.is-hovered {
-        box-shadow: $paper-shadow-2;
-        background-color: $catkin;
-      }
-      &:active,
-      &.is-active {
-        box-shadow: none;
-      }
+      @include button-type-flat;
     }
     &.mod-collapse {
       padding: 0;

--- a/doc/molecules/radio-groups.md
+++ b/doc/molecules/radio-groups.md
@@ -1,0 +1,90 @@
+# Radio Groups
+
+## Usage
+A radio group is a collection of radio controls with labels which are shown as toggle buttons.
+They are included the same way as a normal radio control except that they are wrapped 
+in a container with the class `radio-group`.
+
+<div class="radio-group">
+  <input type="radio" id="r1v1" name="r1" />
+  <label for="r1v1">Cool</label>
+  <input type="radio" id="r1v2" name="r1" />
+  <label for="r1v2">Uncool</label>
+</div>
+```html
+<div class="radio-group">
+  <input type="radio" id="r1v1" name="r1" />
+  <label for="r1v1">Cool</label>
+  <input type="radio" id="r1v2" name="r1" />
+  <label for="r1v2">Uncool</label>
+</div>
+```
+
+## Sizes
+As with normal buttons you can specify the size of the control with the classes
+`mod-small` and `mod-large` (medium is the default).
+
+<div class="radio-group mod-small">
+  <input type="radio" id="r2v1" name="r2" />
+  <label for="r2v1">Cool</label>
+  <input type="radio" id="r2v2" name="r2" />
+  <label for="r2v2">Uncool</label>
+</div>
+<div class="radio-group mod-large">
+  <input type="radio" id="r3v1" name="r3" />
+  <label for="r3v1">Cool</label>
+  <input type="radio" id="r3v2" name="r3" />
+  <label for="r3v2">Uncool</label>
+</div>
+```html
+<div class="radio-group mod-small">
+  <input type="radio" id="r2v1" name="r2" />
+  <label for="r2v1">Cool</label>
+  <input type="radio" id="r2v2" name="r2" />
+  <label for="r2v2">Uncool</label>
+</div>
+<div class="radio-group mod-large">
+  <input type="radio" id="r3v1" name="r3" />
+  <label for="r3v1">Cool</label>
+  <input type="radio" id="r3v2" name="r3" />
+  <label for="r3v2">Uncool</label>
+</div>
+```
+
+## Disabled
+By either adding the attribute `disabled` or the class `is-disabled` to the input you can
+disable single buttons. Disabling the whole control is not supported.
+
+<div class="radio-group">
+  <input type="radio" disabled id="r4v1" name="r4" />
+  <label for="r4v1">Cool</label>
+  <input type="radio" class="is-disabled" id="r4v2" name="r4" />
+  <label for="r4v2">Uncool</label>
+</div>
+```html
+<div class="radio-group">
+  <input type="radio" disabled id="r4v1" name="r4" />
+  <label for="r4v1">Cool</label>
+  <input type="radio" class="is-disabled" id="r4v2" name="r4" />
+  <label for="r4v2">Uncool</label>
+</div>
+```
+
+## Selected value
+To show a button as active / selected you must either add the attribute `checked` or the
+class `is-active` or `is-checked` to the input.
+
+<div class="radio-group">
+  <input type="radio" checked id="r5v1" name="r5" />
+  <label for="r5v1">Cool</label>
+  <input type="radio" id="r5v2" name="r5" />
+  <label for="r5v2">Uncool</label>
+</div>
+```html
+<div class="radio-group">
+  <input type="radio" checked id="r5v1" name="r5" />
+  <label for="r5v1">Cool</label>
+  <input type="radio" id="r5v2" name="r5" />
+  <label for="r5v2">Uncool</label>
+</div>
+```

--- a/molecules/_radio-group.scss
+++ b/molecules/_radio-group.scss
@@ -1,112 +1,56 @@
-$radio-group-background: $primary-color !default;
-$radio-group-color: white !default;
-$radio-group-border: 1px solid lighten($sail, 5%) !default;
-$radio-group-inner-border: 1px solid lighten($sail, 5%) !default;
-$radio-group-background-checked: darken($miroschka, 15%) !default;
-$radio-group-color-checked: white !default;
-$radio-group-border-checked: darken($radio-group-background, 15%) !default;
-$radio-group-background-gray: $secondary-color !default;
-$radio-group-color-gray: $asphalt !default;
-$radio-group-border-gray: $french-gray !default;
+$include-radio-group-css: true !default;
+$radio-group-button-color: $asphalt !default;
+$radio-group-button-background-color: $catkin !default;
+$radio-group-button-active-color: $primary-color !default;
+$radio-group-button-disabled-color: $ghost !default;
+$radio-group-border-radius: $button-border-radius !default;
 
-.radio-group {
-  @include clearfix;
-  input {
-    display: none;
-  }
-
-  label {
-    margin-bottom: 0;
-
-    @include media(medium) {
-      float: left;
-    }
-
-    .radio-group-item {
-      background: $radio-group-background;
-      border-left: $radio-group-border;
-      border-radius: 0;
-      border-right: $radio-group-border;
-      color: $radio-group-color;
-      cursor: pointer;
-      display: inline-block;
+@if $include-radio-group-css {
+  .radio-group {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 0;
+    * {
       font-size: $base-font-size;
-      font-weight: normal;
-      line-height: 1;
-      padding: $button-padding;
-      width: 100%;
-
-      @include media(medium) {
-        border-bottom: $radio-group-border;
-        border-left: 0;
-        border-right: $radio-group-inner-border;
-        border-top: $radio-group-border;
-        width: auto;
-      }
-
-      &:active,
-      &:focus,
-      &:hover {
-        background-color: darken($radio-group-background, 3%);
-      }
     }
-
-    &:first-child .radio-group-item {
-      border-top-left-radius: $base-border-radius;
-      border-top-right-radius: $base-border-radius;
-      border-top: $radio-group-border;
-
-      @include media(medium) {
-        border-bottom-left-radius: $base-border-radius;
-        border-left: $radio-group-border;
-        border-top-left-radius: $base-border-radius;
-        border-top-right-radius: 0;
+    input[type=radio] {
+      display: none;
+      + label {
+        @include button-base;
+        @include button-size-medium;
+        @include button-style($radio-group-button-background-color, $radio-group-button-color);
+        border-radius: 0;
+        margin: 0;
+        &:first-of-type {
+          border-top-left-radius: $radio-group-border-radius;
+          border-bottom-left-radius: $radio-group-border-radius;
+        }
+        &:last-of-type {
+          border-top-right-radius: $radio-group-border-radius;
+          border-bottom-right-radius: $radio-group-border-radius;
+        }
+        &:active {
+          color: $radio-group-button-active-color;
+          box-shadow: $paper-shadow-1;
+        }
       }
-    }
-
-    &:last-child .radio-group-item {
-      border-bottom-left-radius: $base-border-radius;
-      border-bottom-right-radius: $base-border-radius;
-      border-bottom: $radio-group-border;
-
-      @include media(medium) {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: $base-border-radius;
-        border-right: $radio-group-border;
-        border-top-right-radius: $base-border-radius;
+      &:checked + label,
+      &.is-checked + label,
+      &.is-active + label {
+        color: $radio-group-button-active-color;
+        box-shadow: $paper-shadow-1;
+      }
+      &:disabled + label,
+      &.is-disabled + label {
+        color: $radio-group-button-disabled-color;
+        cursor: not-allowed;
       }
     }
-
-    input:checked + .radio-group-item {
-      background-color: darken($radio-group-background, 2%);
-      box-shadow: inset 0 1px 3px 0 $asphalt;
-      color: $radio-group-color-checked;
+    &.mod-small input[type=radio] + label {
+      @include button-size-small;
     }
-
-    input:disabled + .radio-group-item {
-      cursor: not-allowed;
-      opacity: 0.5;
-      box-shadow: 0 0 0 0!important;
-    }
-  }
-}
-
-.radio-group--gray {
-  label {
-    .radio-group-item {
-      background-color: $radio-group-background-gray;
-      color: $radio-group-color-gray;
-      border-right-color: $radio-group-border-gray;
-
-      &:active,
-      &:focus,
-      &:hover {
-        background-color: darken($radio-group-background-gray, 3%);
-      }
-    }
-    input:checked + .radio-group-item {
-      background-color: darken($radio-group-background-gray, 2%);
-      color: $asphalt;
+    &.mod-large input[type=radio] + label {
+      @include button-size-large;
     }
   }
 }


### PR DESCRIPTION
- Implemented style for radio groups. Took styling from toggle buttons https://zalando.invisionapp.com/d/main#/console/10454474/240745484/preview
- Fixed button text style regarding the same document

Example: 
![radio-groups](https://user-images.githubusercontent.com/1099747/28417262-b9c3acc8-6d57-11e7-926c-5cecc668c67f.png)

Documentation example:
https://wholesale-design-system.github.io/styleguide/scss/radio-group