### PR TITLE
fix(table): use standard text line-height for table content

### DIFF
--- a/molecules/_tables.scss
+++ b/molecules/_tables.scss
@@ -54,7 +54,7 @@ table {
     tr {
       th {
         padding: 0 $space-xl 0 $space-m;
-        line-height: $space-xl;
+        line-height: $space-l;
         white-space: nowrap;
         position: relative;
         text-align: left;
@@ -114,7 +114,7 @@ table {
     }
     td {
       padding: 0 $space-xl 0 $space-m;
-      line-height: $space-xl;
+      line-height: $space-l;
     }
     tr.pagination-row td {
       @include inset-spacing-stretch(l);


### PR DESCRIPTION
At the moment tables use excessive line-height (2rem), so multiline text appears as if it was separated by a paragraph break, instead of forming one block:

![image](https://user-images.githubusercontent.com/152606/28922773-c3d44470-785b-11e7-9903-bf79d8110320.png)

This pull requests aligns line-height in tables with other elements (1.5rem), so it appears consistent with other text elements and is more readable:

![image](https://user-images.githubusercontent.com/152606/28922815-eca5eb2e-785b-11e7-9220-5697fad94a6f.png)
